### PR TITLE
Formalize: Daegene Song (2014) - P≠NP

### DIFF
--- a/proofs/attempts/daegene-song-2014-pneqnp/coq/DaegeneSong2014.v
+++ b/proofs/attempts/daegene-song-2014-pneqnp/coq/DaegeneSong2014.v
@@ -1,7 +1,7 @@
 (**
-  DaegeneSong2014.v - Formalization of Daegene Song's 2014 P≠NP attempt
+  DaegeneSong2014.v - Formalization of Daegene Song's 2014 P!=NP attempt
 
-  This file formalizes and refutes Song's claim that P≠NP based on quantum
+  This file formalizes and refutes Song's claim that P!=NP based on quantum
   self-reference. The paper argues that observing a reference frame's evolution
   with respect to itself creates nondeterminism distinguishing NP from P.
 
@@ -90,7 +90,7 @@ Axiom vectors_appear_different :
     theta <> PI ->
     schrodinger_self_reference theta <> heisenberg_self_reference theta.
 
-(** * 5. Why This Doesn't Prove P ≠ NP *)
+(** * 5. Why This Doesn't Prove P != NP *)
 
 (** ** Error 1: The "different" vectors are in different coordinate systems *)
 
@@ -154,7 +154,7 @@ Definition PNotEqualsNP : Prop := ~ PEqualsNP.
 
 (** Song's physical process (P2) is NOT a decision problem *)
 (** It doesn't accept/reject strings, so it's not a language *)
-(** Therefore, the claim "(P2) ∈ NP but (P2) ∉ P" is not well-formed *)
+(** Therefore, the claim "(P2) in NP but (P2) not in P" is not well-formed *)
 
 Axiom song_process_not_a_language :
   ~ exists (L : Language),
@@ -163,18 +163,18 @@ Axiom song_process_not_a_language :
 
 (** * 6. The Core Refutation *)
 
-(** Theorem: Song's argument does not establish P ≠ NP *)
+(** Theorem: Song's argument does not establish P != NP *)
 Theorem song_refutation :
   (* Even if we accept all of Song's setup... *)
   (forall theta : R,
     theta <> R0 ->
     theta <> PI ->
     schrodinger_self_reference theta <> heisenberg_self_reference theta) ->
-  (* It still doesn't prove P ≠ NP *)
+  (* It still doesn't prove P != NP *)
   ~ (PNotEqualsNP).
 Proof.
   intro H_different_vectors.
-  (* We need to show that the difference in vectors doesn't imply P ≠ NP *)
+  (* We need to show that the difference in vectors doesn't imply P != NP *)
   unfold not.
   intro H_assume_p_neq_np.
 
@@ -197,12 +197,12 @@ Proof.
   (* Therefore, Song's argument creates a TYPE ERROR: *)
   (* Cannot apply complexity class membership to a non-decision-problem *)
 
-  (* This is a contradiction - we assumed P ≠ NP follows from Song's setup *)
+  (* This is a contradiction - we assumed P != NP follows from Song's setup *)
   (* but the setup doesn't even define a proper decision problem *)
 
   (* In a fully rigorous proof, we would show that no language L exists *)
   (* corresponding to Song's process (P2), therefore the statement *)
-  (* "(P2) ∈ NP ∧ (P2) ∉ P" is meaningless *)
+  (* "(P2) in NP and (P2) not in P" is meaningless *)
 
   admit. (* Placeholder: full proof requires formalizing the type mismatch *)
 Admitted.
@@ -247,12 +247,12 @@ Axiom error1_coordinate_confusion :
 
 (** Error 2: Misunderstanding of nondeterminism *)
 Axiom error2_nondeterminism_confusion :
-  (* Observer choice of description ≠ computational nondeterminism *)
+  (* Observer choice of description != computational nondeterminism *)
   True.
 
 (** Error 3: Type error in complexity claim *)
 Axiom error3_type_error :
-  (* (P2) is not a decision problem, so "(P2) ∈ NP" is meaningless *)
+  (* (P2) is not a decision problem, so "(P2) in NP" is meaningless *)
   True.
 
 (** Error 4: Physical equivalence ignored *)
@@ -286,7 +286,7 @@ Theorem conclusion :
   (forall theta : R,
     theta <> R0 ->
     schrodinger_self_reference theta <> heisenberg_self_reference theta) ->
-  (* Does not establish P ≠ NP *)
+  (* Does not establish P != NP *)
   True.
 Proof.
   intro H.
@@ -299,7 +299,7 @@ Check what_song_showed.
 Check representation_not_complexity.
 Check conclusion.
 
-(** This formalization demonstrates that Song's 2014 attempt to prove P ≠ NP
+(** This formalization demonstrates that Song's 2014 attempt to prove P != NP
     via quantum self-reference fails due to fundamental misunderstandings about:
     - The nature of computational complexity
     - The equivalence of quantum mechanical pictures


### PR DESCRIPTION
## Summary

This PR formalizes Daegene Song's 2014 P vs NP proof attempt from the paper "The P versus NP Problem in Quantum Physics" (arXiv:1402.6970) in three proof assistants: Coq, Lean 4, and Isabelle/HOL.

The formalization identifies and documents the fundamental gaps in the argument, demonstrating why this approach does not constitute a valid proof of P ≠ NP.

## Paper Overview

**Author**: Daegene Song  
**Year**: 2014 (February)  
**Claim**: P ≠ NP  
**Approach**: Considering P and NP as classes of physical processes (deterministic vs nondeterministic) and arguing that a "self-reference physical process" in quantum theory belongs to NP but not P.

**Source**: Entry #99 on [Woeginger's P vs NP attempts list](https://wscor.win.tue.nl/woeginger/P-versus-NP.htm)

## Formalization Structure

```
proofs/attempts/daegene-song-2014-pneqnp/
├── README.md                      # Detailed analysis and error documentation
├── coq/DaegeneSong2014.v         # Coq formalization with identified gaps
├── lean/DaegeneSong2014.lean     # Lean 4 formalization with identified gaps
└── isabelle/DaegeneSong2014.thy  # Isabelle/HOL formalization with identified gaps
```

## Key Findings

The formalization reveals **5 fundamental errors** in the approach:

### 1. Category Confusion
P and NP are defined over formal computational models (Turing machines), not physical processes. The paper attempts to redefine them in terms of physical processes without establishing a rigorous formal correspondence.

### 2. Missing Formal Definitions
The paper never formally defines:
- What makes a physical process "polynomial time"
- What "self-reference" means in this context
- How to map physical processes to decision problems
- What "deterministic" vs "nondeterministic" means for quantum processes

### 3. Confusion about Quantum Nondeterminism
Quantum "nondeterminism" (superposition, probabilistic measurement outcomes) is NOT the same as computational nondeterminism (parallel exploration of branches). BQP is believed to be different from both P and NP.

### 4. Unjustified Uniqueness Assumption
Even if a process is "nondeterministic", this doesn't prove the problem cannot be solved by ANY deterministic process. The paper conflates:
- "This particular process is nondeterministic"
- "The problem cannot be solved by ANY deterministic process"

### 5. No Rigorous Proof Structure
The paper lacks formal lemmas, precise theorem statements, step-by-step logical derivations, and explicit handling of edge cases required for a Millennium Prize Problem.

## Formalization Approach

Each formalization:
1. **Implements standard complexity theory definitions** (TuringMachine, InP, InNP)
2. **Models the paper's physical process framework** (PhysicalProcess, isDeterministicProcess, etc.)
3. **Defines the self-reference process** from the paper
4. **Attempts the proof** that P ≠ NP using the paper's approach
5. **Uses `sorry`/`Admitted`** to mark exact points where the proof cannot be completed
6. **Documents the gaps** with detailed comments explaining why each step fails

## Testing

- **Lean**: Compiles successfully with expected `sorry` warnings
- **Coq**: Will be verified by CI using Docker (coq 8.20)
- **Isabelle**: Will be verified by CI using Isabelle2025

All formalizations are included in the CI workflow and will be automatically verified on push.

## Educational Value

This formalization serves as:
- A case study in identifying gaps in informal arguments
- An example of using proof assistants to analyze flawed P vs NP attempts
- Documentation of common pitfalls in P vs NP proof attempts (conflating physical and computational models)

## Related Issues

Resolves #113  
Part of #44 (Test all P vs NP attempts formally)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>