### PR TITLE
Add formalization for attempt #69: Carlos Barron-Romero (2010) - P≠NP

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-23T17:09:57.343Z for PR creation at branch issue-470-f352e4565bd1 for issue https://github.com/konard/p-vs-np/issues/470

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-23T17:09:57.343Z for PR creation at branch issue-470-f352e4565bd1 for issue https://github.com/konard/p-vs-np/issues/470

--- a/proofs/attempts/ATTEMPTS.md
+++ b/proofs/attempts/ATTEMPTS.md
@@ -48,7 +48,7 @@ This document provides a comparison of all documented P vs NP proof attempts in 
 | ✓ | Douglas Youvan | 2012 | [D](douglas-youvan-2012-peqnp/) | - | - |
 | ✓ | Dr. Joachim Mertz | 2005 | [D](dr-joachim-mertz-2005-peqnp/) | - | - |
 | ✓ | Eli Halylaurin | 2016 | [E](eli-halylaurin-2016-peqnp/) | - | - |
-| ✗ | Javier A. Arroyo-Figueroa | 2016 | [F](figueroa-2016-pneqnp/) | - | - |
+| ✗ | Javier A. Arroyo-Figueroa | 2016 | [F](figueroa-2016-pneqnp/) | 📎 | 🔷 🔶 |
 | ✓ | Francesco Capasso | 2005 | [F](francesco-capasso-2005-peqnp/) | - | - |
 | ✓ | Frederic Gillet | 2013 | [F](frederic-gillet-2013-peqnp/) | - | - |
 | ✓ | Guohun Zhu | 2007 | [G](guohun-zhu-2007-peqnp/) | 📄 📎 | 🔷 🔶 |
@@ -124,12 +124,12 @@ This document provides a comparison of all documented P vs NP proof attempts in 
 - **Claims P = NP:** 57
 - **Claims P ≠ NP:** 42
 - **Claims unprovable:** 1
-- **With ORIGINAL.md:** 27
-- **With original paper:** 20
-- **With proof/ directory:** 32
-- **With refutation/ directory:** 32
-- **With Lean formalization:** 32
-- **With Rocq formalization:** 32
+- **With ORIGINAL.md:** 28
+- **With original paper:** 22
+- **With proof/ directory:** 33
+- **With refutation/ directory:** 34
+- **With Lean formalization:** 34
+- **With Rocq formalization:** 34
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #470

This PR verifies the formalization for Carlos Barron-Romero's 2010 P≠NP attempt (arXiv:1006.2218v1) and updates the ATTEMPTS.md file.

### Formalization Structure

The attempt is formalized in `proofs/attempts/carlos-barron-romero-2010-pneqnp/` with the following structure:

- **README.md** — Overview of the attempt, the core error (confusing solution-finding with verification), and detailed analysis
- **ORIGINAL.md** — Markdown reconstruction of the paper's key arguments
- **ORIGINAL.pdf** — The original arXiv paper
- **proof/** — Forward proof formalization following the paper's structure
  - `proof/lean/BarronRomeroProof.lean` — Lean 4 formalization
  - `proof/rocq/BarronRomeroProof.v` — Rocq formalization
- **refutation/** — Formal refutation of the argument
  - `refutation/lean/BarronRomeroRefutation.lean` — Lean 4 refutation
  - `refutation/rocq/BarronRomeroRefutation.v` — Rocq refutation

### Core Error Formalized

The paper's Proposition 1.1 claims NP problems have no polynomial algorithm for "checking their solution." This directly contradicts the definition of NP (polynomial-time verification). The paper confuses:
- **Finding** the optimal solution: requires exhaustive search, exponential
- **Verifying** a given solution: O(n) for TSP (check tour validity and cost)

Key theorems in the refutation:
1. `proposition1_1_false` — Prop 1.1 contradicts NP's definition
2. `tsp_verification_polynomial` — TSP verification is O(n)
3. `solving_vs_verifying` — Algorithm 9 solves (not verifies) TSP
4. `barronRomero_invalid_inference_is_false` — The invalid inference is formally refuted

### Changes

- Updated `proofs/attempts/ATTEMPTS.md` with current statistics (regenerated via `scripts/check_attempt_structure.py`)