### PR TITLE
Add Nicholas Argall 2003 undecidability attempt

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T08:18:24.819Z for PR creation at branch issue-558-fa82a20afef8 for issue https://github.com/konard/p-vs-np/issues/558

--- a/experiments/nicholas-argall-2003/argall-source.txt
+++ b/experiments/nicholas-argall-2003/argall-source.txt
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>404 Not Found</title>
+  <link rel="stylesheet" href="/error_docs/styles.css">
+</head>
+<body>
+<div class="page">
+  <div class="main">
+    <h1>Server Error</h1>
+    <div class="error-code">404</div>
+    <h2>Page Not Found</h2>
+    <p class="lead">This page either doesn't exist, or it moved somewhere else.</p>
+    <hr/>
+    <p>That's what you can do</p>
+    <div class="help-actions">
+      <a href="javascript:location.reload();">Reload Page</a>
+      <a href="javascript:history.back();">Back to Previous Page</a>
+      <a href="/">Home Page</a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/proofs/attempts/ATTEMPTS.md
+++ b/proofs/attempts/ATTEMPTS.md
@@ -91,6 +91,7 @@ This document provides a comparison of all documented P vs NP proof attempts in 
 | ✓ | Narendra S. Chaudhari | 2009 | [Narendra S. Chaudhari (2009) - P=NP Attempt](narendra-chaudhari-2009-peqnp/) | - | 🔷 🔶 |
 | ? | Natalia L. Malinina | 2012 | [Natalia L. Malinina (2012) - P vs NP is Unprovable in ZFC](natalia-malinina-2012-unprovable/) | 📄 | 🔷 🔶 |
 | ? | Newton C.A. da Costa & Francisco A. Doria | 2003 | [Formalization: N.C.A. da Costa & F.A. Doria (2003) - P vs NP Unprovability Claim](ncada-costa-fa-doria-2003-unprovable/) | - | - |
+| ? | Nicholas Argall | 2003 | [Nicholas Argall (2003) - P=NP is Undecidable](nicholas-argall-2003-undecidable/) | 📄 | 🔷 🔶 |
 | ✓ | Peng Cui | 2014 | [Peng Cui (2014) - P=NP Claim](peng-cui-2014-peqnp/) | 📄 📎 | 🔷 🔶 |
 | ✓ | Wen-Qi Duan | 2012 | [Qi Duan (2012) - P=NP Proof Attempt](qi-duan-2012-peqnp/) | - | - |
 | ✗ | Radoslaw Hofman | 2006 | [Radoslaw Hofman (2006) - P≠NP Attempt](radoslaw-hofman-2006-pneqnp/) | 📄 📎 | 🔷 🔶 |

--- a/proofs/attempts/nicholas-argall-2003-undecidable/README.md
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/README.md
@@ -1,0 +1,57 @@
+# Nicholas Argall (2003) - P=NP is Undecidable
+
+**Navigation:** [↑ Back to Repository Root](../../../README.md) | [All Attempts](../README.md)
+
+---
+
+## Metadata
+
+- **Attempt ID**: 8
+- **Author**: Nicholas Argall
+- **Date**: 25 March 2003
+- **Claim**: undecidable / unprovable status for the P versus NP question
+- **Status**: **REFUTED** - the argument confuses formal expressibility with formal completeness and does not establish ZFC independence
+- **Source**: [Woeginger's P-versus-NP page](https://wscor.win.tue.nl/woeginger/P-versus-NP.htm), entry #8
+
+## Summary
+
+Woeginger records Argall's short argument as follows: a provable answer to the P=NP question allegedly requires a complete and consistent formal statement of that question; by invoking Goedel's theorem, Argall concludes that P=NP is undecidable.
+
+The source ASCII file linked from Woeginger's page is no longer retrievable from the current live site. The `original/` directory therefore contains a reconstruction from Woeginger's entry rather than a verbatim archival copy.
+
+## Main Argument
+
+The reconstructed argument has three steps:
+
+1. If P=NP has a provable answer, then the question must have a complete and consistent formal statement.
+2. Goedel's incompleteness theorem says that no sufficiently strong consistent formal system is complete.
+3. Therefore P=NP has no provable answer, so it is undecidable.
+
+## Formal Error
+
+The critical gap is the first step. A mathematical statement can be precisely formalized in an incomplete theory without requiring the theory to decide that statement. Completeness of the ambient formal system is not a prerequisite for a statement to be meaningful or for the system to prove some particular theorem.
+
+Goedel's theorem gives a conditional metatheorem: every sufficiently strong, effectively axiomatized, consistent theory has some undecidable sentence. It does not imply that an arbitrary sentence expressible in the theory, such as P=NP, is undecidable.
+
+To prove that P=NP is independent of a formal theory such as ZFC, one would need at least:
+
+1. A precise formal sentence representing P=NP in that theory.
+2. A proof that the theory does not prove that sentence.
+3. A proof that the theory does not prove its negation.
+
+Equivalently, under appropriate soundness/completeness assumptions, one would need model-theoretic witnesses for both sides. Argall's argument provides none of these.
+
+## Formalization
+
+- [Proof notes in Lean](proof/lean/ArgallProof.lean) encode the claimed inference as axioms and mark the missing theorem.
+- [Proof notes in Rocq](proof/rocq/ArgallProof.v) mirror the forward argument and isolate the invalid step as an explicit bridge assumption.
+- [Refutation in Lean](refutation/lean/ArgallRefutation.lean) proves that expressibility plus incompleteness does not imply independence.
+- [Refutation in Rocq](refutation/rocq/ArgallRefutation.v) gives the same structural refutation.
+
+## References
+
+- Gerhard J. Woeginger, "The P-versus-NP page", entry #8.
+- Kurt Goedel, "On Formally Undecidable Propositions of Principia Mathematica and Related Systems I", 1931.
+- Scott Aaronson, "Is P Versus NP Formally Independent?"
+
+**Part of**: [Issue #558](https://github.com/konard/p-vs-np/issues/558) | **Parent Issue**: [#44](https://github.com/konard/p-vs-np/issues/44)

--- a/proofs/attempts/nicholas-argall-2003-undecidable/original/ORIGINAL.md
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/original/ORIGINAL.md
@@ -1,0 +1,17 @@
+# Reconstruction of Nicholas Argall's 2003 Argument
+
+This is not a verbatim source copy. It reconstructs the short argument from Woeginger's preserved description of entry #8.
+
+## Reconstructed Claim
+
+P=NP is undecidable.
+
+## Reconstructed Argument
+
+1. A provable answer to the P=NP question requires a complete and consistent formal statement of the question.
+2. Goedel's incompleteness theorem rules out complete and consistent sufficiently strong formal systems.
+3. Therefore P=NP cannot have a provable answer.
+
+## Source Availability
+
+Woeginger's page describes the proof as a short ASCII file, but the currently linked source file was not available during this reconstruction. The live catalog entry remains the citable source for the summary.

--- a/proofs/attempts/nicholas-argall-2003-undecidable/original/README.md
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/original/README.md
@@ -1,0 +1,11 @@
+# Original Source Notes
+
+Woeginger's entry #8 links to a short ASCII file for Nicholas Argall's 25 March 2003 argument. A current request to the linked source on `wscor.win.tue.nl` returns a 404 HTML page, so this directory stores a reconstruction rather than a verbatim original.
+
+The reconstruction in [ORIGINAL.md](ORIGINAL.md) is limited to the information preserved in Woeginger's live entry:
+
+- the author,
+- the date,
+- the claim that P=NP is undecidable,
+- the appeal to a complete and consistent formal statement of the problem,
+- and the invocation of Goedel's theorem.

--- a/proofs/attempts/nicholas-argall-2003-undecidable/proof/README.md
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/proof/README.md
@@ -1,0 +1,12 @@
+# Forward Formalization Notes
+
+These files encode Argall's claimed inference in a deliberately small abstract proof-theory model.
+
+The formalization distinguishes:
+
+- a statement being expressible in a theory,
+- a theory being complete,
+- a theory proving or refuting a particular statement,
+- and a statement being independent of the theory.
+
+The attempted proof can only reach the conclusion by adding an invalid bridge axiom: that every expressible statement in any incomplete theory is undecidable. The refutation files show why this bridge is false.

--- a/proofs/attempts/nicholas-argall-2003-undecidable/proof/lean/ArgallProof.lean
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/proof/lean/ArgallProof.lean
@@ -1,0 +1,49 @@
+/-
+  Forward formalization of Nicholas Argall's 2003 undecidability claim.
+
+  The file records the claimed Goedel-style inference and isolates the
+  unsupported bridge needed to conclude that P=NP is undecidable.
+-/
+
+namespace ArgallProofAttempt
+
+axiom Theory : Type
+axiom Sentence : Type
+
+axiom ZFC : Theory
+axiom PeqNP : Sentence
+
+axiom ExpressibleIn : Theory -> Sentence -> Prop
+axiom Consistent : Theory -> Prop
+axiom Complete : Theory -> Prop
+axiom Proves : Theory -> Sentence -> Prop
+axiom Refutes : Theory -> Sentence -> Prop
+
+def IndependentOf (T : Theory) (phi : Sentence) : Prop :=
+  Not (Proves T phi) /\ Not (Refutes T phi)
+
+-- Argall's reconstruction starts from the correct observation that P=NP can be
+-- represented as a formal sentence.
+axiom p_eq_np_is_expressible : ExpressibleIn ZFC PeqNP
+
+-- A Goedel-style metatheorem: suitable theories are not complete.
+axiom goedel_incompleteness_for_zfc : Consistent ZFC -> Not (Complete ZFC)
+
+-- This is the invalid bridge in the argument. Incompleteness of a theory does
+-- not imply that every expressible sentence is independent of that theory.
+axiom argall_bridge :
+  forall (T : Theory) (phi : Sentence),
+    ExpressibleIn T phi -> Consistent T -> Not (Complete T) -> IndependentOf T phi
+
+theorem claimed_p_eq_np_undecidable :
+    Consistent ZFC -> IndependentOf ZFC PeqNP := by
+  intro hzfc
+  exact argall_bridge ZFC PeqNP p_eq_np_is_expressible hzfc
+    (goedel_incompleteness_for_zfc hzfc)
+
+-- What is missing is a theorem specifically about PeqNP, not a generic
+-- consequence of incompleteness.
+axiom missing_specific_independence_argument :
+  Not (Proves ZFC PeqNP) /\ Not (Refutes ZFC PeqNP)
+
+end ArgallProofAttempt

--- a/proofs/attempts/nicholas-argall-2003-undecidable/proof/rocq/ArgallProof.v
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/proof/rocq/ArgallProof.v
@@ -1,0 +1,51 @@
+(*
+  Forward formalization of Nicholas Argall's 2003 undecidability claim.
+
+  The file records the claimed Goedel-style inference and isolates the
+  unsupported bridge needed to conclude that P=NP is undecidable.
+*)
+
+Module ArgallProofAttempt.
+
+Parameter Theory : Type.
+Parameter Sentence : Type.
+
+Parameter ZFC : Theory.
+Parameter PeqNP : Sentence.
+
+Parameter ExpressibleIn : Theory -> Sentence -> Prop.
+Parameter Consistent : Theory -> Prop.
+Parameter Complete : Theory -> Prop.
+Parameter Proves : Theory -> Sentence -> Prop.
+Parameter Refutes : Theory -> Sentence -> Prop.
+
+Definition IndependentOf (T : Theory) (phi : Sentence) : Prop :=
+  ~ Proves T phi /\ ~ Refutes T phi.
+
+Parameter p_eq_np_is_expressible : ExpressibleIn ZFC PeqNP.
+
+Parameter goedel_incompleteness_for_zfc :
+  Consistent ZFC -> ~ Complete ZFC.
+
+(*
+  This is the invalid bridge in the argument. Incompleteness of a theory does
+  not imply that every expressible sentence is independent of that theory.
+*)
+Parameter argall_bridge :
+  forall (T : Theory) (phi : Sentence),
+    ExpressibleIn T phi -> Consistent T -> ~ Complete T -> IndependentOf T phi.
+
+Theorem claimed_p_eq_np_undecidable :
+    Consistent ZFC -> IndependentOf ZFC PeqNP.
+Proof.
+  intro hzfc.
+  apply (argall_bridge ZFC PeqNP).
+  - exact p_eq_np_is_expressible.
+  - exact hzfc.
+  - exact (goedel_incompleteness_for_zfc hzfc).
+Qed.
+
+Parameter missing_specific_independence_argument :
+  ~ Proves ZFC PeqNP /\ ~ Refutes ZFC PeqNP.
+
+End ArgallProofAttempt.

--- a/proofs/attempts/nicholas-argall-2003-undecidable/refutation/README.md
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/refutation/README.md
@@ -1,0 +1,7 @@
+# Refutation Notes
+
+Argall's argument fails because incompleteness is existential, not universal.
+
+Goedel incompleteness yields some undecidable sentence for each suitable consistent theory. It does not follow that each formally expressible sentence is undecidable. The P=NP sentence may be expressible in ZFC while still being provable, refutable, or independent; incompleteness alone does not decide which case holds.
+
+The Lean and Rocq files prove this structural point with an abstract countermodel: a theory may be incomplete and still prove a particular expressible statement.

--- a/proofs/attempts/nicholas-argall-2003-undecidable/refutation/lean/ArgallRefutation.lean
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/refutation/lean/ArgallRefutation.lean
@@ -1,0 +1,81 @@
+/-
+  Refutation of Nicholas Argall's 2003 undecidability claim.
+
+  The key point is structural: incompleteness of a theory says that some
+  sentence is undecidable, not that every expressible sentence is undecidable.
+-/
+
+namespace ArgallRefutation
+
+structure Theory where
+  Sentence : Type
+  proves : Sentence -> Prop
+  refutes : Sentence -> Prop
+  expressible : Sentence -> Prop
+  complete : Prop
+  consistent : Prop
+
+def IndependentOf (T : Theory) (phi : T.Sentence) : Prop :=
+  Not (T.proves phi) /\ Not (T.refutes phi)
+
+def Incomplete (T : Theory) : Prop :=
+  Not T.complete
+
+-- Argall's invalid bridge, stated as a property so it can be refuted.
+def IncompletenessMakesEveryExpressibleSentenceIndependent (T : Theory) : Prop :=
+  forall phi : T.Sentence,
+    T.expressible phi -> T.consistent -> Incomplete T -> IndependentOf T phi
+
+inductive TwoSentences where
+  | p_eq_np
+  | goedel_sentence
+
+def counterTheory : Theory where
+  Sentence := TwoSentences
+  proves := fun phi =>
+    match phi with
+    | TwoSentences.p_eq_np => True
+    | TwoSentences.goedel_sentence => False
+  refutes := fun _ => False
+  expressible := fun _ => True
+  complete := False
+  consistent := True
+
+theorem counterTheory_is_consistent : counterTheory.consistent := by
+  trivial
+
+theorem counterTheory_is_incomplete : Incomplete counterTheory := by
+  intro h
+  exact h
+
+theorem p_eq_np_is_expressible_in_counterTheory :
+    counterTheory.expressible TwoSentences.p_eq_np := by
+  trivial
+
+theorem p_eq_np_is_not_independent_in_counterTheory :
+    Not (IndependentOf counterTheory TwoSentences.p_eq_np) := by
+  intro h
+  exact h.left True.intro
+
+theorem argall_bridge_is_false :
+    Not (IncompletenessMakesEveryExpressibleSentenceIndependent counterTheory) := by
+  intro bridge
+  have hind := bridge TwoSentences.p_eq_np
+    p_eq_np_is_expressible_in_counterTheory
+    counterTheory_is_consistent
+    counterTheory_is_incomplete
+  exact p_eq_np_is_not_independent_in_counterTheory hind
+
+-- The valid consequence of incompleteness is only existential.
+def HasSomeIndependentSentence (T : Theory) : Prop :=
+  exists phi : T.Sentence, IndependentOf T phi
+
+theorem existential_is_weaker_than_argall_bridge :
+    IncompletenessMakesEveryExpressibleSentenceIndependent counterTheory ->
+    HasSomeIndependentSentence counterTheory := by
+  intro bridge
+  exact Exists.intro TwoSentences.goedel_sentence
+    (bridge TwoSentences.goedel_sentence (by trivial)
+      counterTheory_is_consistent counterTheory_is_incomplete)
+
+end ArgallRefutation

--- a/proofs/attempts/nicholas-argall-2003-undecidable/refutation/rocq/ArgallRefutation.v
+++ b/proofs/attempts/nicholas-argall-2003-undecidable/refutation/rocq/ArgallRefutation.v
@@ -1,0 +1,99 @@
+(*
+  Refutation of Nicholas Argall's 2003 undecidability claim.
+
+  The key point is structural: incompleteness of a theory says that some
+  sentence is undecidable, not that every expressible sentence is undecidable.
+*)
+
+Module ArgallRefutation.
+
+Record Theory := {
+  Sentence : Type;
+  proves : Sentence -> Prop;
+  refutes : Sentence -> Prop;
+  expressible : Sentence -> Prop;
+  complete : Prop;
+  consistent : Prop
+}.
+
+Definition IndependentOf (T : Theory) (phi : Sentence T) : Prop :=
+  ~ proves T phi /\ ~ refutes T phi.
+
+Definition Incomplete (T : Theory) : Prop :=
+  ~ complete T.
+
+Definition IncompletenessMakesEveryExpressibleSentenceIndependent
+    (T : Theory) : Prop :=
+  forall phi : Sentence T,
+    expressible T phi -> consistent T -> Incomplete T -> IndependentOf T phi.
+
+Inductive TwoSentences : Type :=
+  | p_eq_np
+  | goedel_sentence.
+
+Definition counterTheory : Theory :=
+  {|
+    Sentence := TwoSentences;
+    proves := fun phi =>
+      match phi with
+      | p_eq_np => True
+      | goedel_sentence => False
+      end;
+    refutes := fun _ => False;
+    expressible := fun _ => True;
+    complete := False;
+    consistent := True
+  |}.
+
+Theorem counterTheory_is_consistent : consistent counterTheory.
+Proof.
+  exact I.
+Qed.
+
+Theorem counterTheory_is_incomplete : Incomplete counterTheory.
+Proof.
+  unfold Incomplete, counterTheory; simpl.
+  intro h.
+  exact h.
+Qed.
+
+Theorem p_eq_np_is_expressible_in_counterTheory :
+    expressible counterTheory p_eq_np.
+Proof.
+  exact I.
+Qed.
+
+Theorem p_eq_np_is_not_independent_in_counterTheory :
+    ~ IndependentOf counterTheory p_eq_np.
+Proof.
+  intro h.
+  exact (proj1 h I).
+Qed.
+
+Theorem argall_bridge_is_false :
+    ~ IncompletenessMakesEveryExpressibleSentenceIndependent counterTheory.
+Proof.
+  intro bridge.
+  pose proof (bridge p_eq_np
+    p_eq_np_is_expressible_in_counterTheory
+    counterTheory_is_consistent
+    counterTheory_is_incomplete) as hind.
+  exact (p_eq_np_is_not_independent_in_counterTheory hind).
+Qed.
+
+Definition HasSomeIndependentSentence (T : Theory) : Prop :=
+  exists phi : Sentence T, IndependentOf T phi.
+
+Theorem existential_is_weaker_than_argall_bridge :
+    IncompletenessMakesEveryExpressibleSentenceIndependent counterTheory ->
+    HasSomeIndependentSentence counterTheory.
+Proof.
+  intro bridge.
+  exists goedel_sentence.
+  apply bridge.
+  - exact I.
+  - exact counterTheory_is_consistent.
+  - exact counterTheory_is_incomplete.
+Qed.
+
+End ArgallRefutation.


### PR DESCRIPTION
## Summary

Fixes #558.

Adds Woeginger entry #8 for Nicholas Argall's 25 March 2003 claim that P=NP is undecidable.

## Changes

- Added `proofs/attempts/nicholas-argall-2003-undecidable/` with README metadata, argument summary, known gap, and references.
- Added `original/` reconstruction notes because the linked ASCII source currently returns a 404 HTML page; the failed retrieval is preserved in `experiments/nicholas-argall-2003/argall-source.txt`.
- Added Lean and Rocq proof/refutation notes showing the invalid bridge from incompleteness to independence of this specific sentence.
- Regenerated `proofs/attempts/ATTEMPTS.md` so Nicholas Argall appears with the undecidable/unprovable marker.

## Verification

- `lake env lean proofs/attempts/nicholas-argall-2003-undecidable/proof/lean/ArgallProof.lean`
- `lake env lean proofs/attempts/nicholas-argall-2003-undecidable/refutation/lean/ArgallRefutation.lean`
- `python3 scripts/check_attempt_structure.py --path proofs/attempts/nicholas-argall-2003-undecidable`
- `python3 scripts/test_check_attempt_structure.py`

Rocq files were added but not compiled locally because `coqc` is not installed in the runner environment.
